### PR TITLE
Update crypto.c

### DIFF
--- a/src/providers/dime/common/crypto.c
+++ b/src/providers/dime/common/crypto.c
@@ -620,6 +620,7 @@ _generate_ed25519_keypair(void)
         PUSH_ERROR_OPENSSL();
         _secure_wipe(result, sizeof(ED25519_KEY));
         free(result);
+        result = NULL;
         RET_ERROR_PTR(ERR_UNSPEC, "could not generate ed25519 secret key");
     }
 


### PR DESCRIPTION
`crypto.c:628 -- (error) Returning/dereferencing 'result' after it is deallocated / released`

Returning a freed pointer is a subtle error which may lead to dangling pointer bugs, e.g. http://stackoverflow.com/a/1025604

Found by https://github.com/bryongloden/cppcheck
